### PR TITLE
Fixed sorting, double dipping, and spell0 matching

### DIFF
--- a/MQ2Bot.cpp
+++ b/MQ2Bot.cpp
@@ -64,7 +64,7 @@ extern char PLUGIN_NAME[MAX_PATH];
 
 #endif
 */
-// char PLUGIN_NAME[MAX_PATH] = "MQ2Bot"; // this needs reenabled when not using mmobugs source code
+char PLUGIN_NAME[MAX_PATH] = "MQ2Bot"; // this needs reenabled when not using mmobugs source code
 PreSetup("MQ2Bot");
 
 // defines
@@ -1503,6 +1503,9 @@ void CheckMemmedSpells()
 								WriteChatf("\arMQ2Bot\aw::\ayAdded: \aw%s (%s)", vMemmedSpells[nGem].SpellName, vMemmedSpells[nGem].SpellCat);
 							else
 								WriteChatf("\arMQ2Bot\aw::\amDetected: \aw%s (%s)", vMemmedSpells[nGem].SpellName, vMemmedSpells[nGem].SpellCat);
+							//renji:
+							//for loop was "return"-ing to avoid adding to master if found, which skips the sort call when change=true
+							bool bFoundSpell = false;
 							int vSize = vMaster.size();
 							for (int i = 0; i < vSize; i++)
 							{
@@ -1510,11 +1513,14 @@ void CheckMemmedSpells()
 								{
 									WriteChatf("\arMQ2Bot\aw::\amKnown: \aw%s (%s)", vMemmedSpells[nGem].SpellName, vMemmedSpells[nGem].SpellCat);
 									vMaster[i] = vMemmedSpells[nGem];
-									return;
+									bFoundSpell = true;
+									break;
+									//return;
 								}
 							}
-							if (vMemmedSpells[nGem].SpellTypeOption != ::OPTIONS::ZERO)
-								vMaster.push_back(vMemmedSpells[nGem]);
+							if (!bFoundSpell)
+								if (vMemmedSpells[nGem].SpellTypeOption != ::OPTIONS::ZERO)
+									vMaster.push_back(vMemmedSpells[nGem]);
 						}
 					}
 				}
@@ -2149,6 +2155,15 @@ void CreateAA()
 		sprintf_s(szSpell, "Spell%dName", i);
 		if (GetPrivateProfileString(INISection, szSpell, NULL, szTemp, MAX_STRING, INIFileName))
 		{
+			//renji: avoid double dipping from heal AA's, etc.
+			bool bFound = false;
+			for (int i = 0; szAA[i]; i++)
+				if (!_stricmp(szTemp, szAA[i]))
+				{
+					bFound = true;
+				}
+			if (!bFound) continue; //this spell is not in the AA list
+			//end
 			aaIndex = GetAAIndexByName(szTemp);
 			if (aaIndex > 0)
 			{
@@ -2156,6 +2171,7 @@ void CreateAA()
 				if (aa && GetSpellByID(aa->SpellID))
 				{
 					BotSpell spell;
+					spell.IniMatch = i; //renji: this wasn't set, causing AA to hijack the top spells
 					spell.Spell = GetSpellByID(aa->SpellID);
 					if (GetCharInfo()->pSpawn->mActorClient.Class == 3) // one off shit that is misnamed.  should probably double check to see if this is fixed now 20160717.
 						if (strstr(szTemp, "Inquisitor's Judg"))
@@ -2191,6 +2207,7 @@ void CreateAA()
 				if (aa && GetSpellByID(aa->SpellID) && (int)aa->ReuseTimer > 0)
 				{
 					BotSpell spell;
+					spell.IniMatch = -1; //renji: temp workaround so doesn't match Spell0
 					spell.Spell = GetSpellByID(aa->SpellID);
 					strcpy_s(spell.SpellName, szTemp);
 					spell.CanIReprioritize = 1;
@@ -2365,6 +2382,15 @@ void CreateHeal()
 			aaIndex = GetAAIndexByName(szTemp);
 			if (aaIndex > 0)
 			{
+				//renji: avoid double dipping from normal AA's, etc.
+				bool bFound = false;
+				for (int i = 0; szHeal[i]; i++)
+					if (!_stricmp(szTemp, szHeal[i]))
+					{
+						bFound = true;
+					}
+				if (!bFound) continue; //this spell is not in the heal list
+				//end
 				aa = pAltAdvManager->GetAAById(aaIndex);
 				if (aa && GetSpellByID(aa->SpellID))
 				{
@@ -2426,6 +2452,7 @@ void CreateHeal()
 				if (aa && GetSpellByID(aa->SpellID))
 				{
 					BotSpell spell;
+					spell.IniMatch = -1; //renji: temp workaround so doesn't match Spell0
 					spell.Spell = GetSpellByID(aa->SpellID);
 					strcpy_s(spell.SpellName, szTemp);
 					spell.ID = aa->ID;
@@ -2802,10 +2829,8 @@ void ListCommand(PSPAWNINFO pChar, PCHAR szLine)
 }
 void MemmedCommand(PSPAWNINFO pChar, PCHAR szLine)
 {
-	WriteChatf("MemmedCommand::No more crashing please!");
-	DebugSpewAlwaysFile("MemmedCommand::No more crashing please!");
 	CheckMemmedSpells();
-	//SortSpellVector(vMemmedSpells);
+	//SortSpellVector(vMemmedSpells); //we probably shouldn't sort this since they're in gem-order
 }
 #pragma endregion Commands
 
@@ -2861,7 +2886,10 @@ void LoadBotSpell(vector<_BotSpell> &v, char VectorName[MAX_STRING])
 		sprintf_s(szSpell, "Spell%dNamedOnly", v[i].IniMatch);
 		v[i].NamedOnly = GetPrivateProfileInt(INISection, szSpell, defNamedOnly, INIFileName);
 		sprintf_s(szSpell, "Spell%dPriority", v[i].IniMatch);
-		if (v[i].CanIReprioritize)
+		//renji:
+		//need to discuss how you want to handle this, but as it stands, spells found in the
+		//ini are not pulling the priority value because you set CanIReprioritize to 0
+		//if (v[i].CanIReprioritize)
 			v[i].Priority = GetPrivateProfileInt(INISection, szSpell, defPriority, INIFileName);
 		v[i].LastTargetID = 0;
 		v[i].LastCast = 0;


### PR DESCRIPTION
Issues addressed:
1. **Double dipping**
     _CheckAA()_ and _CheckHeal()_ were both counting spells from the INI. Now checking the INI spell against the hard-coded AA/Heal lists.

2. **Sorting**
     _CheckMemmedSpells()_ would hard return if a known spell was found, which caused the routine to skip re-sorting _vMaster_ if changes were made. Added a boolean check.

3. **Priority and IniMatch issues**
     _CanIReprioritize_ was being set to 0 on spells/AA loaded from the INI which skipped the priority being pulled from the INI. This was causing AA to load with a "**0**" priority. Skipped the check for _CanIReprioritize_ and let the INI/default sort it out. Need to discuss what the goal is for this (figured pulling from the INI is correct so users can customize).

     _BOTSPELL.IniMatch_ was not being set for AA when a match was found in the INI.
     _BOTSPELL.IniMatch_ defaulting to "**0**" caused AA to inherit the data of _Spell0_ if it existed in the INI file.
     Now setting IniMatch to the respective value if a match is found, else set it to "**-1**" to avoid _GetPrivateProfile_ from matching to _Spell0_.

I will try to break commits into more focused fixes in the future. As I was working to identify the sorting issue, I stumbled on all of these and I don't want to go back and break them into chunks now.

--renji
